### PR TITLE
chore: Update .gitignore for JetBrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,6 +403,23 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+# JetBrains Rider / IntelliJ IDEA
+.idea/*
+# Shared project settings
+!.idea/codeStyles/
+!.idea/inspectionProfiles/
+!.idea/runConfigurations/
+!.idea/vcs.xml
+!.idea/modules.xml
+!.idea/*.iml
+# Ignore user workspace-level files
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/usage.statistics.xml
+.idea/dictionaries/
+*.iws
+*.sln.DotSettings.user
+*.user
 
 # DocFx
 .cache


### PR DESCRIPTION
### 🚀 What's New?
Updated `.gitignore` to properly handle JetBrains IDE (Rider/IntelliJ) project files.  
This change ensures that only relevant, shareable configuration files are tracked while ignoring user-specific or machine-dependent files (e.g., `workspace.xml`, `tasks.xml`, `.sln.DotSettings.user`).

### 🔗 Related Issues
N/A

### 📝 Additional Information
- Ignored user-specific JetBrains IDE files to prevent unnecessary conflicts.
- Kept sharable project settings (e.g., `codeStyles/`, `inspectionProfiles/`, `runConfigurations/`) under version control.
- Provides a cleaner Git history and reduces merge conflicts across contributors.
